### PR TITLE
SupportWindowsNT

### DIFF
--- a/src/Open.php
+++ b/src/Open.php
@@ -36,6 +36,7 @@ class Open
                 break;
 
             case 'Windows':
+            case 'Windows NT':
                 $command = null === $app ? 'start ""' : sprintf('start "" %s', escapeshellarg($app));
                 break;
 


### PR DESCRIPTION
Single-line fix to uname case statement to add support for Windows 10 and Windows Server environments.